### PR TITLE
Feature/0.0.4

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -11,6 +11,8 @@
     <file url="file://$PROJECT_DIR$/caching-reporter/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/caching-spring-boot-starter/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/caching-spring-boot-starter/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/caching-x-processor/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/caching-x-processor/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/src/main/resources" charset="UTF-8" />
   </component>

--- a/README.md
+++ b/README.md
@@ -203,7 +203,6 @@ sequenceDiagram
     OtherApp->>PubSub: Listens to topic
     PubSub-->>OtherApp: Receives message("key")
     OtherApp->>OtherApp: Invalidates local L1 for "key"```
-```
 </details>
 
 ## Using the API: A Deeper Look
@@ -231,6 +230,7 @@ sequenceDiagram
 // Static keys
 @CacheX(key = "'global:settings'")
 ```
+</details>
 
 ### Programmatic Caching with `CacheService`
 
@@ -265,6 +265,7 @@ The project is organized into a clean, multi-module structure. Click on a module
 -   [**`caching-caffeine-adapter`**](./caching-caffeine-adapter/README.md): A high-performance L1 cache adapter using Caffeine.
 -   [**`caching-redis-adapter`**](./caching-redis-adapter/README.md): A resilient L2 cache adapter using Redis.
 -   [**`caching-spring-boot-starter`**](./caching-spring-boot-starter/README.md): Provides seamless auto-configuration for Spring Boot applications.
+-   [**`caching-x-processor`**](./caching-x-processor/README.md): Compile-time annotation processor that validates `@CacheX` usage and provides early error detection.
 
 ## Contributing
 

--- a/caching-caffeine-adapter/pom.xml
+++ b/caching-caffeine-adapter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.pedromossi</groupId>
         <artifactId>caching-x</artifactId>
-        <version>0.0.3</version>
+        <version>0.0.4</version>
     </parent>
 
     <artifactId>caching-caffeine-adapter</artifactId>

--- a/caching-core/pom.xml
+++ b/caching-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.pedromossi</groupId>
         <artifactId>caching-x</artifactId>
-        <version>0.0.3</version>
+        <version>0.0.4</version>
     </parent>
 
     <artifactId>caching-core</artifactId>

--- a/caching-redis-adapter/pom.xml
+++ b/caching-redis-adapter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.pedromossi</groupId>
         <artifactId>caching-x</artifactId>
-        <version>0.0.3</version>
+        <version>0.0.4</version>
     </parent>
 
     <artifactId>caching-redis-adapter</artifactId>

--- a/caching-reporter/pom.xml
+++ b/caching-reporter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.pedromossi</groupId>
         <artifactId>caching-x</artifactId>
-        <version>0.0.3</version>
+        <version>0.0.4</version>
     </parent>
 
     <artifactId>caching-reporter</artifactId>

--- a/caching-spring-boot-starter/pom.xml
+++ b/caching-spring-boot-starter/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.pedromossi</groupId>
         <artifactId>caching-x</artifactId>
-        <version>0.0.3</version>
+        <version>0.0.4</version>
     </parent>
 
     <dependencies>

--- a/caching-spring-boot-starter/pom.xml
+++ b/caching-spring-boot-starter/pom.xml
@@ -120,5 +120,25 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>21</source>
+                    <target>21</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>com.pedromossi</groupId>
+                            <artifactId>caching-x-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/caching-spring-boot-starter/src/test/java/com/pedromossi/caching/starter/CachingDataTypesIT.java
+++ b/caching-spring-boot-starter/src/test/java/com/pedromossi/caching/starter/CachingDataTypesIT.java
@@ -238,7 +238,7 @@ public class CachingDataTypesIT extends IntegrationTest {
     void shouldHandleLoaderExceptions() {
         // Given
         String key = "exception-key";
-        RuntimeException expectedException = new RuntimeException("Simulated loader failure");
+        RuntimeException expectedException = new RuntimeException("Failed to load value for key");
         Supplier<String> failingLoader = () -> {
             throw expectedException;
         };
@@ -251,7 +251,7 @@ public class CachingDataTypesIT extends IntegrationTest {
         // When & Then
         assertThatThrownBy(() -> cacheService.getOrLoad(key, typeRef, failingLoader))
                 .isInstanceOf(RuntimeException.class)
-                .hasMessage("Simulated loader failure");
+                .hasMessage("Failed to load value for key: " + key);
 
         // Verify no caching occurred
         verify(l1CacheProvider, never()).put(anyString(), any());

--- a/caching-x-processor/README.md
+++ b/caching-x-processor/README.md
@@ -1,0 +1,60 @@
+# Caching-X-Processor Module
+
+The **CacheXProcessor** is a compile-time annotation processor that validates the usage of the `@CacheX` annotation, providing early error detection and ensuring proper caching implementation.
+
+## Overview
+
+This processor automatically validates methods annotated with `@CacheX` during compilation, catching common mistakes before runtime and providing clear error messages to developers.
+
+## Features
+
+- **Compile-Time Validation**: Catches errors during compilation, not at runtime
+- **Method Modifier Validation**: Ensures methods can be properly proxied by Spring AOP
+- **SpEL Expression Validation**: Validates syntax and parameter references in cache keys
+- **Clear Error Messages**: Provides descriptive compilation errors with specific guidance
+
+## How It Works
+
+The processor is automatically registered and runs during compilation when the `@CacheX` annotation is detected. It performs the following validations:
+
+### 1. Annotation Target Validation
+Ensures `@CacheX` is only applied to methods (not classes, fields, etc.).
+
+### 2. Method Modifier Validation
+Validates that annotated methods are not:
+- `private` - Cannot be proxied by Spring AOP
+- `static` - No instance context for caching
+- `final` - Cannot be overridden by proxies
+
+### 3. SpEL Expression Validation
+- **Syntax Validation**: Ensures the SpEL expression can be parsed
+- **Parameter Validation**: Verifies that all referenced parameters exist in the method signature
+
+## Usage
+
+The processor is automatically included when you use the Caching-X library. No additional configuration is required.
+
+```xml
+<dependency>
+    <groupId>com.pedromossi</groupId>
+    <artifactId>caching-x</artifactId>
+    <version>0.0.3</version>
+</dependency>
+```
+
+## Benefits
+
+1. **Early Error Detection**: Catches issues at compile time instead of runtime
+2. **Better Developer Experience**: Clear error messages guide proper usage
+3. **Prevents Common Mistakes**: Automatically validates method modifiers and SpEL expressions
+4. **Zero Configuration**: Works automatically when the library is included
+5. **IDE Integration**: Errors appear directly in your IDE during development
+
+## Technical Details
+
+- **Processor**: `com.pedromossi.caching.processor.CacheXProcessor`
+- **Supported Java Version**: Java 21+
+- **Dependencies**: Spring Expression Language (SpEL) for validation
+- **Registration**: Automatic via `@AutoService` annotation
+
+The processor is built using the Java Annotation Processing API and integrates seamlessly with Maven, Gradle, and IDEs that support annotation processing.

--- a/caching-x-processor/pom.xml
+++ b/caching-x-processor/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.pedromossi</groupId>
+        <artifactId>caching-x</artifactId>
+        <version>0.0.3</version>
+    </parent>
+
+    <artifactId>caching-x-processor</artifactId>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.pedromossi</groupId>
+            <artifactId>caching-core</artifactId>
+            <version>0.0.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.auto.service</groupId>
+            <artifactId>auto-service</artifactId>
+            <version>1.1.1</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-expression</artifactId>
+            <version>6.1.10</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/caching-x-processor/pom.xml
+++ b/caching-x-processor/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pedromossi</groupId>
         <artifactId>caching-x</artifactId>
-        <version>0.0.3</version>
+        <version>0.0.4</version>
     </parent>
 
     <artifactId>caching-x-processor</artifactId>
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.pedromossi</groupId>
             <artifactId>caching-core</artifactId>
-            <version>0.0.3</version>
+            <version>0.0.4</version>
         </dependency>
 
         <dependency>

--- a/caching-x-processor/src/main/java/com/pedromossi/caching/processor/CacheXProcessor.java
+++ b/caching-x-processor/src/main/java/com/pedromossi/caching/processor/CacheXProcessor.java
@@ -1,0 +1,162 @@
+// Dentro do módulo caching-x-processor
+package com.pedromossi.caching.processor;
+
+import com.google.auto.service.AutoService;
+import com.pedromossi.caching.annotation.CacheX;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+
+import javax.annotation.processing.*;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.*;
+import javax.tools.Diagnostic;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Annotation processor for the @CacheX annotation.
+ *
+ * <p>This processor performs compile-time validation of methods annotated with @CacheX,
+ * ensuring they meet the required constraints for proper caching functionality. It validates
+ * method modifiers and SpEL expressions used in cache keys.</p>
+ *
+ * <p>The processor performs the following validations:</p>
+ * <ul>
+ *   <li>Ensures @CacheX is only applied to methods</li>
+ *   <li>Validates that annotated methods are not private, static, or final</li>
+ *   <li>Validates SpEL expression syntax in cache keys</li>
+ *   <li>Verifies that SpEL parameter references exist in the method signature</li>
+ * </ul>
+ *
+ * @author Pedro Mossi
+ * @since 1.0
+ */
+@AutoService(Processor.class) // Registers the processor automatically
+@SupportedAnnotationTypes("com.pedromossi.caching.annotation.CacheX") // Specifies which annotation to process
+@SupportedSourceVersion(SourceVersion.RELEASE_21) // Supported Java version
+public class CacheXProcessor extends AbstractProcessor {
+
+    /**
+     * Messager instance for reporting compilation errors and warnings.
+     */
+    private Messager messager;
+
+    /**
+     * SpEL expression parser for validating cache key expressions.
+     */
+    private final SpelExpressionParser spelParser = new SpelExpressionParser();
+
+    /**
+     * Initializes the processor with the processing environment.
+     *
+     * @param processingEnv the processing environment providing utilities for processing
+     */
+    @Override
+    public synchronized void init(ProcessingEnvironment processingEnv) {
+        super.init(processingEnv);
+        this.messager = processingEnv.getMessager();
+    }
+
+    /**
+     * Processes all elements annotated with @CacheX in the current compilation round.
+     *
+     * <p>This method is called by the compiler for each round of annotation processing.
+     * It validates all methods annotated with @CacheX, checking their modifiers and
+     * SpEL expressions for correctness.</p>
+     *
+     * @param annotations the annotation types requested to be processed
+     * @param roundEnv environment for information about the current and prior rounds
+     * @return false to allow other processors to process the same annotations
+     */
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        // Iterate over all elements (methods) annotated with @CacheX
+        for (Element element : roundEnv.getElementsAnnotatedWith(CacheX.class)) {
+            // The @CacheX annotation can only be applied to methods
+            if (element.getKind() != ElementKind.METHOD) {
+                error(element, "@CacheX can only be applied to methods.");
+                continue;
+            }
+
+            ExecutableElement method = (ExecutableElement) element;
+            validateMethodModifiers(method);
+            validateSpelExpression(method);
+        }
+        return false; // Allows other processors to also act on these annotations
+    }
+
+    /**
+     * Validates that the annotated method does not have invalid modifiers.
+     *
+     * <p>Methods annotated with @CacheX cannot be private, static, or final as these
+     * modifiers would prevent proper proxy-based caching mechanisms from working.</p>
+     *
+     * @param method the method to validate
+     */
+    private void validateMethodModifiers(ExecutableElement method) {
+        Set<Modifier> modifiers = method.getModifiers();
+        if (modifiers.contains(Modifier.PRIVATE)) {
+            error(method, "Methods with @CacheX cannot be 'private'.");
+        }
+        if (modifiers.contains(Modifier.STATIC)) {
+            error(method, "Methods with @CacheX cannot be 'static'.");
+        }
+        if (modifiers.contains(Modifier.FINAL)) {
+            error(method, "Methods with @CacheX cannot be 'final'.");
+        }
+    }
+
+    /**
+     * Validates the SpEL expression syntax and parameter references in the cache key.
+     *
+     * <p>This method performs two levels of validation:</p>
+     * <ol>
+     *   <li>Validates the SpEL expression syntax using Spring's SpEL parser</li>
+     *   <li>Ensures all parameter references (e.g., #paramName) in the expression
+     *       correspond to actual method parameters</li>
+     * </ol>
+     *
+     * @param method the method whose @CacheX annotation contains the SpEL expression
+     */
+    private void validateSpelExpression(ExecutableElement method) {
+        CacheX annotation = method.getAnnotation(CacheX.class);
+        String spelKey = annotation.key();
+
+        // 1. Validate SpEL expression syntax
+        try {
+            spelParser.parseExpression(spelKey);
+        } catch (Exception e) {
+            error(method, "The SpEL expression in the key is invalid: %s. Error: %s", spelKey, e.getMessage());
+            return; // If syntax is invalid, no point in checking parameters
+        }
+
+        // 2. Validate that SpEL parameters exist in the method signature
+        Set<String> methodParamNames = method.getParameters().stream()
+                .map(p -> p.getSimpleName().toString())
+                .collect(Collectors.toSet());
+
+        // Simple regex to find variables like #name
+        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile("#(\\w+)");
+        java.util.regex.Matcher matcher = pattern.matcher(spelKey);
+
+        while (matcher.find()) {
+            String spelParamName = matcher.group(1);
+            if (!methodParamNames.contains(spelParamName)) {
+                error(method, "The SpEL expression references parameter '#%s', which does not exist in the method signature.", spelParamName);
+            }
+        }
+    }
+
+    /**
+     * Helper method to simplify error message logging.
+     *
+     * <p>Formats and prints error messages using the processor's messager,
+     * associating them with the specific code element that caused the error.</p>
+     *
+     * @param element the code element associated with the error
+     * @param msg the error message format string
+     * @param args arguments for the format string
+     */
+    private void error(Element element, String msg, Object... args) {
+        messager.printMessage(Diagnostic.Kind.ERROR, String.format(msg, args), element);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.pedromossi</groupId>
     <artifactId>caching-x</artifactId>
-    <version>0.0.3</version>
+    <version>0.0.4</version>
     <packaging>pom</packaging>
     <name>Caching X Library :: Parent</name>
     <description>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <module>caching-core</module>
         <module>caching-caffeine-adapter</module>
         <module>caching-redis-adapter</module>
+        <module>caching-x-processor</module>
         <module>caching-reporter</module>
         <module>caching-spring-boot-starter</module>
     </modules>


### PR DESCRIPTION
This pull request introduces a new module, `caching-x-processor`, which adds compile-time validation for the `@CacheX` annotation, enhances the caching service with concurrent load prevention, and updates project dependencies and documentation. Below is a summary of the most important changes grouped by theme:

### New Module: `caching-x-processor`
* Introduced the `caching-x-processor` module, a compile-time annotation processor for validating `@CacheX` usage. It ensures proper caching implementation by validating method modifiers, SpEL expressions, and annotation targets. (`caching-x-processor/pom.xml` [[1]](diffhunk://#diff-7a9ec213da45656958fc4bfc38c33baf047dfaea5c6bd46326fbc2b8e2654cf5R1-R41)], `caching-x-processor/src/main/java/com/pedromossi/caching/processor/CacheXProcessor.java` [[2]](diffhunk://#diff-c022c9925eae926e9616ddaa6d491f8bbfa3173eeb429964ce0b48f15a4c4590R1-R199)])
* Added a detailed README for the `caching-x-processor` module, explaining its features, usage, and benefits. (`caching-x-processor/README.md` [[caching-x-processor/README.mdR1-R60](diffhunk://#diff-436268639892c784857738263ef3ae2cee7c7a14d48ca4513ac08e6cd8756895R1-R60)])

### Enhancements to `MultiLevelCacheService`
* Added a `ConcurrentHashMap` to track ongoing loading operations for cache keys, preventing multiple concurrent loads for the same key. (`caching-core/src/main/java/com/pedromossi/caching/impl/MultiLevelCacheService.java` [[caching-core/src/main/java/com/pedromossi/caching/impl/MultiLevelCacheService.javaR52-R59](diffhunk://#diff-64defaa39e4e83b9b1f6af97c176195532a5984ac72cd9a6ebf19512a4ad81d8R52-R59)])
* Refactored the `getOrLoad` method to use `FutureTask` for synchronized data loading, ensuring only one data source query is executed per key at a time. (`caching-core/src/main/java/com/pedromossi/caching/impl/MultiLevelCacheService.java` [[caching-core/src/main/java/com/pedromossi/caching/impl/MultiLevelCacheService.javaL218-L226](diffhunk://#diff-64defaa39e4e83b9b1f6af97c176195532a5984ac72cd9a6ebf19512a4ad81d8L218-L226)])

### Dependency and Build Updates
* Bumped the project version from `0.0.3` to `0.0.4` across all modules. (`caching-caffeine-adapter/pom.xml` [[1]](diffhunk://#diff-086d15637c8e3eae182780d5830b0c067fbf537bd743cccc9a7935363ce31713L10-R10)], `caching-core/pom.xml` [[2]](diffhunk://#diff-f78a991757bdc44e5d6ae60ccd7fe1f704cd629c978b16a2bab69d93430f1ce0L10-R10)], `caching-redis-adapter/pom.xml` [[3]](diffhunk://#diff-89b7e7500023ca5738ff7839d57569eaad0b7adc32add595ab46d798dc289157L10-R10)], `caching-reporter/pom.xml` [[4]](diffhunk://#diff-5616348e14d4f40d2fcfaa80fe078f3d91a170368291ebd808640b92df489e9cL10-R10)], `caching-spring-boot-starter/pom.xml` [Fff0cd5dL7R7])
* Updated the Maven build configuration in `caching-spring-boot-starter` to include the `caching-x-processor` as an annotation processor and set Java version to 21. (`caching-spring-boot-starter/pom.xml` [[caching-spring-boot-starter/pom.xmlR123-R142](diffhunk://#diff-6d22e1d15091587f1bb5399138fcc91d0bd635f3263338f0b49b7ee5a5ba29e2R123-R142)])

### Documentation Improvements
* Added the `caching-x-processor` module to the project structure in the main README, with a description of its purpose. (`README.md` [[README.mdR268](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R268)])
* Fixed formatting issues in the `sequenceDiagram` section of the README. (`README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L206)], [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R233)])

### Test Updates
* Updated test cases in `CachingDataTypesIT` to reflect the new error message format for loader exceptions in `getOrLoad`. (`caching-spring-boot-starter/src/test/java/com/pedromossi/caching/starter/CachingDataTypesIT.java` [[1]](diffhunk://#diff-cb98cfcfd395469fb563a216afd5f123aa2288c77d18406981083b1c7d772cedL241-R241)], [[2]](diffhunk://#diff-cb98cfcfd395469fb563a216afd5f123aa2288c77d18406981083b1c7d772cedL254-R254)])